### PR TITLE
Updates conda installation guid

### DIFF
--- a/.github/workflows/urlcheck.yml
+++ b/.github/workflows/urlcheck.yml
@@ -20,4 +20,4 @@ jobs:
         force_pass : false
         exclude_files: /scripts/create_external_link_file.py,/source/dev_section/external_links.rst
         exclude_patterns: https://enmap-box.readthedocs.io/en/latest/general/glossary.html,https://tiles.wmflabs.org,https://fbinter.stadt-berlin.de/fb/wfs
-        exclude_urls: http://localhost:8000/,https://github.com/mygithubaccount/enmap-box-documentation-fork.git,https://www.gnu.org/licenses/gpl-3.0.en.html,https://www.gnu.org/licenses/
+        exclude_urls: http://localhost:8000/,https://github.com/mygithubaccount/enmap-box-documentation-fork.git,https://www.gnu.org/licenses/gpl-3.0.en.html,https://www.gnu.org/licenses/,https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh

--- a/source/usr_section/usr_installation.rst
+++ b/source/usr_section/usr_installation.rst
@@ -1,7 +1,3 @@
-
-
-
-
 .. |download_link| raw:: html
 
    <a href="https://plugins.qgis.org/plugins/enmapboxplugin/" target="_blank">https://plugins.qgis.org/plugins/enmapboxplugin/</a>
@@ -14,6 +10,9 @@ Installation
 
 The EnMAP-Box is a plugin for QGIS. It required the QGIS python API and various other python packages.
 Here we describe how you can install QGIS, the required python packages and the EnMAP-Box plugin.
+
+
+.. _usr_installation_install_qgis:
 
 1. Install QGIS
 ===============
@@ -49,17 +48,19 @@ Here we describe how you can install QGIS, the required python packages and the 
       .. note::
 
          As of June 2025, the official QGIS page https://qgis.org/en/site/forusers/download.html
-         shows the following notice:
+         has the following notice:
 
          .. image:: /img/installation_macos_qgiswarning.png
 
 
 
-         However, we have made better experiences in using :ref:`conda <usr_installation_qgis_conda>` to
-         install QGIS and all python requirements to run the EnMAP-Box
-         (on macOS Sequoia 15.5 (24F74), Intel MacBook 2010 and Mac Mini 2024).
+         We have made better experiences in using conda to
+         install QGIS and all python packages require to run the EnMAP-Box
+         (tested on macOS Sequoia 15.5 (24F74), Intel MacBook 2010 and Mac Mini 2024).
 
-         Therefore, we please follow the instructions give in the *Conda* tab.
+         Therefore, please follow the installation guide given in the *Conda* tab.
+
+
 
       ..
          Therefore, please install QGIS either using **conda**, or using
@@ -90,13 +91,29 @@ Here we describe how you can install QGIS, the required python packages and the 
 
       **Install QGIS with conda (cross-platform)**
 
-      Conda is a cross-platform package manager that allows install software in separated environments.
+      Conda is a cross-platform package manager that allows to install software in separated environments. We recommend
+      installing conda using `Miniforge <https://conda-forge.org/download>`_, a minimal installer which
+      by default installs conda packages from the `conda-forge <https://conda-forge.org/>`_ channel.
 
-      It is recommended to use Miniforge, a minimal installer for conda specific to the
-      `conda-forge <https://conda-forge.org/>`_ channel.
+      *Linux / Unix / MacOS:*
 
-      You can get the Miniforge Installer from https://conda-forge.org/download/.
+          .. code-block:: bash
 
+            # download install script
+            curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+
+            # run install script
+            sh Miniforge3-$(uname)-$(uname -m).sh
+
+      *Windows:*
+
+            Download and run the miniforge installer from https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe
+
+
+      When done, continue with the installation of `QGIS and python dependencies <usr_installation_install_dependencies_>`_ in conda.
+
+
+.. _usr_installation_install_dependencies:
 
 2. Install Python Dependencies
 ==============================
@@ -235,61 +252,83 @@ Here we describe how you can install QGIS, the required python packages and the 
        .. note::
          This step needs to be repeated after updates to the QGIS.app.
 
-         Do not-update packages like numpy or GDAL with pip. This will break the QGIS application.
+         Do not-update packages like numpy or GDAL with pip, as this might break parts of your QGIS application.
 
    .. group-tab:: Conda
 
          **Install a python environment for the EnMAP-Box**
 
-         #. Open the Miniforge Prompt from the start menu.
+         #. Open the `Miniforge <https://conda-forge.org>`_ prompt
 
             .. image:: /img/windows_start_miniforge.png
 
-         #. Select the uri of a conda environment from https://github.com/EnMAP-Box/enmap-box/tree/main/.env/conda
-            that you like to install for running the EnMAP-Box:
+
+         #. Install QGIS and python dependencies, using one of the conda environment files (`enmapbox_*.yml`) from
+            https://github.com/EnMAP-Box/enmap-box/tree/main/.env/conda, e.g.
+
+            .. code-block:: batch
+
+                conda env create -n enmapbox --file=https://raw.githubusercontent.com/EnMAP-Box/enmap-box/refs/heads/main/.env/conda/enmapbox_full.yml
+
+            ``-n <name>`` can be used to change the environment name.
+
+            The environment files provided for download vary by QGIS release and the amount of python packages that is installed.
+
+            * *full* environments contains *all* python packages, including those used by single EnMAP-Box applications only.
+            * *light* environments contain python packages that are required to run most and all core EnMAP-Box applications.
+            * *ltr* environments use the current `QGIS Long Term release <https://qgis.org/resources/roadmap/#release-schedule>`_
+                    instead of the latest (newest) QGIS version available in conda.
+
+
+            Use the *raw content* uri to download and install an EnMAP-Box conda environment from github.
 
             .. list-table::
                :header-rows: 1
 
-               *  - Name
+               *  - Environment
                   - Size
-                  - Notes
                   - Path
 
-               *  - `enmapbox_light_latest.yml`
-                  -
-                  - QGIS Latest Release (LR) with python dependencies core/most EnMAP-Box applications
-                  - https://github.com/EnMAP-Box/enmap-box/blob/main/.env/conda/enmapbox_light_latest.yml
+               *  - `enmapbox_light`
+                  - 4.58 GB
+                  - https://raw.githubusercontent.com/EnMAP-Box/enmap-box/refs/heads/main/.env/conda/enmapbox_light.yml
 
-               *  - `enmapbox_light_longterm.yml`
-                  -
-                  - QGIS Latest Release (LTR) with python dependencies core/most EnMAP-Box applications
-                  - https://github.com/EnMAP-Box/enmap-box/blob/main/.env/conda/enmapbox_light_longterm.yml
+               *  - `enmapbox_light_ltr`
+                  - 4.65 GB
+                  - https://raw.githubusercontent.com/EnMAP-Box/enmap-box/refs/heads/main/.env/conda/enmapbox_light_ltr.yml
 
-               *  - `enmapbox_full_longterm`
-                  -
-                  - QGIS Long Term Release (LTR) with python dependencies for all EnMAP-Box applications
-                  - https://github.com/EnMAP-Box/enmap-box/blob/main/.env/conda/enmapbox_full_longterm.yml
+               *  - `enmapbox_full`
+                  - 6.46 GB
+                  - https://raw.githubusercontent.com/EnMAP-Box/enmap-box/refs/heads/main/.env/conda/enmapbox_full.yml
 
-               *  - `enmapbox_full_latest.yml`
-                  -
-                  - QGIS Latest Release (LR) with python dependencies for all EnMAP-Box applications
-                  - https://github.com/EnMAP-Box/enmap-box/blob/main/.env/conda/enmapbox_full_latest.yml
+               *  - `enmapbox_full_ltr`
+                  - 6.90 GB
+                  - https://raw.githubusercontent.com/EnMAP-Box/enmap-box/refs/heads/main/.env/conda/enmapbox_full_ltr.yml
 
 
 
-         #. Download and install the selected conda environment yml file, e.g.
 
-            .. code-block:: batch
-
-               mamba env create -n enmapbox --file=C:\Users\username\Downloads\enmapbox_full_longterm.yml
-
-         #. Activate the "enmapbox" environment and open QGIS by executing:
+         #. Activate the conda environment and start QGIS:
 
             .. code-block:: batch
 
                activate enmapbox
                qgis
+
+        .. note::
+
+            QGIS is developing rapidly. To keep an environment *<env_name>* up to date, call:
+
+            .. code-block:: bash
+
+                conda env update -n <env_name> --file=<env_name>.yml --prune
+
+            To delete a conda environment, call:
+
+            .. code-block:: bash
+
+                conda env remove -n <env_name>
+
 
 
 3. Install EnMAP-Box
@@ -300,7 +339,7 @@ Here we describe how you can install QGIS, the required python packages and the 
 
       **Install EnMAP-Box Plugin via the QGIS Plugin Manager**
 
-      1. Call ``qgis&`` to open QGIS in an X-Window
+      1. Start QGIS
       2. Go to Plugins -> Manage and Install Plugins
       3. Search for 'EnMAP-Box'
       4. Click on 'Install Plugin'

--- a/source/usr_section/usr_installation.rst
+++ b/source/usr_section/usr_installation.rst
@@ -23,8 +23,8 @@ Here we describe how you can install QGIS, the required python packages and the 
 
       **Install QGIS via the official Standalone/OSGeo4W Installer**
 
-         Install either the current QGIS Long Term Release (LTR) or the current QGIS Latest Release (LR) to run the latest EnMAP-Box.
-         You can `get the QGIS Standalone Installer here <https://www.qgis.org/en/site/forusers/alldownloads.html#windows>`_.
+         Install either the current QGIS Long Term Release (LTR) or the current QGIS Latest Release (LR) to run the latest EnMAP-Box
+         using the QGIS installer from https://www.qgis.org/en/site/forusers/alldownloads.html#windows.
 
          For beginners, we recommend using the standalone installers. More advanced QGIS users can use OSGeo4W installer,
          which eases updates of existing QGIS installation.


### PR DESCRIPTION
updates conda installation
- replaces `mamba` by `conda` because of [read more](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html#fresh-install-recommended)
- skipped the *.yml download step and installes from --file=<ur>.yml directry (because simpler)
- updated environment file descriptions
- 
addresses #118
addresses https://github.com/EnMAP-Box/enmap-box/issues/1194

